### PR TITLE
Use external miniconda role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Ansible playbooks
+# Ansible playbooks
 
 This reposiory contains playbooks to deploy the infrastructure at National Genomics
 Infrastructure.
@@ -55,6 +55,7 @@ __NOTE__: The following assume you have ansible installed in your machine, if no
 
 ```bash
 $> sudo pip install ansible
+$> ansible-galaxy install robinandeer.miniconda
 ```
 
 ### Create a testing environment

--- a/nas.yml
+++ b/nas.yml
@@ -7,7 +7,10 @@
   # Switch to the production user in the NAS for all tasks to be executed
   sudo_user: '{{ user }}'
   sudo: yes
+
+  vars:
+    miniconda_home: '~/.miniconda'
   
   roles:
-    - miniconda
+    - robinandeer.miniconda
     - nas

--- a/processing.yml
+++ b/processing.yml
@@ -8,6 +8,9 @@
   sudo_user: '{{ user }}'
   sudo: yes
 
+  vars:
+    miniconda_url: '~/.miniconda'
+
   roles:
-    - miniconda
+    - robinandeer.miniconda
     - processing

--- a/roles/nas/templates/bash_profile.j2
+++ b/roles/nas/templates/bash_profile.j2
@@ -11,8 +11,7 @@ NO_COLOUR="\[\033[0m\]"
 
 PS1="$NO_COLOUR\u@\h$NO_COLOUR:\w$YELLOW\$(parse_git_branch)$NO_COLOUR\$ "
 
+# Add miniconda to the path
+export PATH="{{ miniconda_home }}/bin:$PATH"
 
-# added by Anaconda 1.8.0 installer
-export PATH="/home/{{ user }}/.miniconda/bin:$PATH"
-
-source activate master &> /dev/null
+source activate prod &> /dev/null

--- a/roles/processing/templates/bash_profile.j2
+++ b/roles/processing/templates/bash_profile.j2
@@ -11,11 +11,7 @@ NO_COLOUR="\[\033[0m\]"
 
 PS1="$NO_COLOUR\u@\h$NO_COLOUR:\w$YELLOW\$(parse_git_branch)$NO_COLOUR\$ "
 
+# Add miniconda and bcl2fastq to the path
+export PATH="{{ miniconda_home }}/bin:${PATH}:{{ bcl2fastq_install_dir }}/bin"
 
-# added by Anaconda 1.8.0 installer
-export PATH="/home/{{ user }}/.miniconda/bin:$PATH"
-
-# Add bcl2fastq to the path
-export PATH=$PATH:{{ bcl2fastq_install_dir }}/bin
-
-source activate master &> /dev/null
+source activate prod &> /dev/null


### PR DESCRIPTION
The integrated Miniconda role was already very re-usable so I based a Ansible Galaxy role off it awhile ago

I believe I've improved it by e.g. adding a base ``.condarc`` file (optional) and introduced Travis testing.